### PR TITLE
Remove last three digits of dates to avoid random test fails

### DIFF
--- a/src/files/wip/CoreProperties.test.ts
+++ b/src/files/wip/CoreProperties.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it, run } from 'https://deno.land/x/tincan@1.0.1/mod.ts';
+import {
+	describe,
+	expect,
+	it,
+	run,
+} from 'https://deno.land/x/tincan@1.0.1/mod.ts';
 
 import { serialize } from '../../utilities/dom.ts';
 import { CoreProperties } from './CoreProperties.ts';
@@ -8,7 +13,12 @@ describe('CoreProperties', () => {
 		const now = new Date().toISOString();
 		const instance = new CoreProperties('');
 
-		expect(serialize(await instance.$$$toNode())).toBe(
+		expect(
+			serialize(await instance.$$$toNode()).replace(
+				/(.\d{3})(?=Z\<)/g,
+				''
+			)
+		).toBe(
 			// It's more chatty than the original XML, but it is not incorrect.
 			// @TODO maybe report this to slimdom some time
 			`
@@ -22,7 +32,9 @@ describe('CoreProperties', () => {
 					<dcterms:created xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="dcterms:W3CDTF">${now}</dcterms:created>
 					<dcterms:modified xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="dcterms:W3CDTF">${now}</dcterms:modified>
 				</cp:coreProperties>
-			`.replace(/\n|\t/g, ''),
+			`
+				.replace(/\n|\t/g, '')
+				.replace(/(.\d{3})(?=Z\<)/g, '')
 		);
 	});
 });

--- a/src/files/wip/CoreProperties.test.ts
+++ b/src/files/wip/CoreProperties.test.ts
@@ -1,9 +1,4 @@
-import {
-	describe,
-	expect,
-	it,
-	run,
-} from 'https://deno.land/x/tincan@1.0.1/mod.ts';
+import { describe, expect, it, run } from 'https://deno.land/x/tincan@1.0.1/mod.ts';
 
 import { serialize } from '../../utilities/dom.ts';
 import { CoreProperties } from './CoreProperties.ts';
@@ -13,12 +8,7 @@ describe('CoreProperties', () => {
 		const now = new Date().toISOString();
 		const instance = new CoreProperties('');
 
-		expect(
-			serialize(await instance.$$$toNode()).replace(
-				/(.\d{3})(?=Z\<)/g,
-				''
-			)
-		).toBe(
+		expect(serialize(await instance.$$$toNode()).replace(/(.\d{3})(?=Z\<)/g, '')).toBe(
 			// It's more chatty than the original XML, but it is not incorrect.
 			// @TODO maybe report this to slimdom some time
 			`
@@ -34,7 +24,7 @@ describe('CoreProperties', () => {
 				</cp:coreProperties>
 			`
 				.replace(/\n|\t/g, '')
-				.replace(/(.\d{3})(?=Z\<)/g, '')
+				.replace(/(.\d{3})(?=Z\<)/g, ''),
 		);
 	});
 });

--- a/src/files/wip/CoreProperties.test.ts
+++ b/src/files/wip/CoreProperties.test.ts
@@ -8,7 +8,7 @@ describe('CoreProperties', () => {
 		const now = new Date().toISOString();
 		const instance = new CoreProperties('');
 
-		expect(serialize(await instance.$$$toNode()).replace(/(.\d{3})(?=Z\<)/g, '')).toBe(
+		expect(serialize(await instance.$$$toNode()).replace(/(.\d{3})(?=Z)/g, '')).toBe(
 			// It's more chatty than the original XML, but it is not incorrect.
 			// @TODO maybe report this to slimdom some time
 			`
@@ -24,7 +24,7 @@ describe('CoreProperties', () => {
 				</cp:coreProperties>
 			`
 				.replace(/\n|\t/g, '')
-				.replace(/(.\d{3})(?=Z\<)/g, ''),
+				.replace(/(.\d{3})(?=Z)/g, ''),
 		);
 	});
 });


### PR DESCRIPTION
Hi @wvbe! I'm using `docxml` on a side project (😛) and I love it, but there is a small issue.

The specific unit test that I've modified randomly fails due to the use of dates and the comparison of those. The timing is not 100% accurate, and there is a small chance that the time calculated on line 13 is not the exact same one that is calculated on line 17. I’ve added a regex that removes the last three digits of an ISO date so `2023-01-11T10:39:54.340Z` becomes `2023-01-11T10:39:54Z`.