### PR TITLE
Un-deprecate table width property

### DIFF
--- a/src/properties/table-properties.test.ts
+++ b/src/properties/table-properties.test.ts
@@ -18,7 +18,7 @@ describe('Table formatting', () => {
 	test(
 		`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
 			<w:tblStyle w:val="afkicken-van-de-opkikkers" />
-			<w:tblW w:val="1200" w:type="dxa" />
+			<w:tblW w:w="1200" w:type="dxa" />
 			<w:tblLook
 				w:firstColumn="1"
 				w:firstRow="1"
@@ -101,7 +101,7 @@ describe('Table formatting', () => {
 	describe('Setting table width to a "%" string', () => {
 		test(
 			`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
-				<w:tblW w:val="100%" w:type="nil" />
+				<w:tblW w:w="100%" w:type="nil" />
 			</w:tblPr>`,
 			{
 				width: { length: '100%', unit: 'nil' },
@@ -112,7 +112,7 @@ describe('Table formatting', () => {
 	describe('Setting table width to an unannotated value', () => {
 		test(
 			`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
-				<w:tblW w:val="420" w:type="nil" />
+				<w:tblW w:w="420" w:type="nil" />
 			</w:tblPr>`,
 			{
 				width: { length: '420', unit: 'nil' },

--- a/src/properties/table-properties.ts
+++ b/src/properties/table-properties.ts
@@ -13,14 +13,15 @@ export type TableProperties = {
 	 * @deprecated Use the {@link Table} `columnWidths` prop instead.
 	 */
 	width?:
-		| null
-		| number
-		| '`${number}%'
-		| string
-		| {
-				length: '`${number}%' | string | number;
-				unit: null | 'nil' | 'auto' | 'dxa' | 'pct';
-		  };
+	| null
+	| number
+	| '`${number}%'
+	| string
+	| {
+		length: '`${number}%' | string | number;
+		unit: null | 'nil' | 'auto' | 'dxa' | 'pct' | undefined;
+	}
+	| undefined;
 	/**
 	 * When set to `true`, the column widths as specified to the {@link Table} component are used
 	 * strictly. If not set, or set to `false`, the specified column widths are considered a
@@ -107,7 +108,7 @@ export function tablePropertiesFromNode(node: Node | null): TableProperties {
 						"insideV": docxml:ct-border(${QNS.w}insideV)
 					},
 					"width": ./${QNS.w}tblW/map {
-						"length": ./@${QNS.w}val/string(),
+						"length": ./@${QNS.w}w/string(),
 						"unit": ./@${QNS.w}type/string()
 					},
 					"strictColumnWidths": boolean(./${QNS.w}tblLayout/@${QNS.w}type = "fixed")
@@ -126,7 +127,7 @@ export function tablePropertiesToNode(tblpr: TableProperties = {}): Node {
 				attribute ${QNS.w}val { $style }
 			} else (),
 			if (exists($width)) then element ${QNS.w}tblW {
-				attribute ${QNS.w}val { $width('length') },
+				attribute ${QNS.w}w { $width('length') },
 				attribute ${QNS.w}type { $width('unit') }
 			} else (),
 			if (exists($activeConditions)) then element ${QNS.w}tblLook {

--- a/src/properties/table-properties.ts
+++ b/src/properties/table-properties.ts
@@ -10,7 +10,7 @@ export type TableProperties = {
 	 */
 	style?: string | null;
 	/**
-	 * @deprecated Use the {@link Table} `columnWidths` prop instead.
+	 * Sets the width for the entire table, can be either a percent or absolute measurement.
 	 */
 	width?:
 	| null


### PR DESCRIPTION
This PR is mean to un-deprecate the width property for tables. This eases things for making tables in a .docx file proportional to the page, instead of a fixed value. 

It also corrects the use of the w:val attribute inside tablW. It is now w:w. 