### PR TITLE
Adopt the use `ContentTypesXml` and implement support for SVG images

### DIFF
--- a/examples/images.tsx
+++ b/examples/images.tsx
@@ -1,16 +1,35 @@
 /** @jsx Docx.jsx */
-import Docx, { cm, Image, Paragraph, Text } from '../mod.ts';
+import Docx, { cm, Image, Paragraph, Section, Text } from '../mod.ts';
 
 await Docx.fromJsx(
-	<Paragraph>
-		<Text>
-			<Image
-				data={Deno.readFile('test/spacekees.jpeg')}
-				width={cm(16)}
-				height={cm(16)}
-				title="Title"
-				alt="Description"
-			/>
-		</Text>
-	</Paragraph>,
+	<Section>
+		<Paragraph>
+			<Text>
+				<Image
+					data={Deno.readFile('test/spacekees.jpeg')}
+					width={cm(16)}
+					height={cm(16)}
+					title="Title"
+					alt="Description"
+				/>
+			</Text>
+		</Paragraph>
+		<Paragraph>
+			<Text>Next image will look different if your word processor supports SVG.</Text>
+		</Paragraph>
+		<Paragraph>
+			<Text>
+				<Image
+					data={Deno.readFile('test/spacekees.jpeg')}
+					dataExtensions={{
+						svg: Deno.readTextFile('test/git.svg'),
+					}}
+					width={cm(16)}
+					height={cm(16)}
+					title="Title"
+					alt="Description"
+				/>
+			</Text>
+		</Paragraph>
+	</Section>,
 ).toFile('images.docx');

--- a/src/Docx.ts
+++ b/src/Docx.ts
@@ -227,10 +227,15 @@ export class Docx<PropsGeneric extends { [key: string]: unknown } = { [key: stri
 				: locationOrZipArchive instanceof Uint8Array
 				? await Archive.fromUInt8Array(locationOrZipArchive)
 				: locationOrZipArchive;
-		return new Docx<PropsGeneric>(
-			await ContentTypesXml.fromArchive(archive, FileLocation.contentTypes),
-			await RelationshipsXml.fromArchive(archive, FileLocation.relationships),
+
+		const contentTypes = await ContentTypesXml.fromArchive(archive, FileLocation.contentTypes);
+		const relationships = await RelationshipsXml.fromArchive(
+			archive,
+			contentTypes,
+			FileLocation.relationships,
 		);
+
+		return new Docx<PropsGeneric>(contentTypes, relationships);
 	}
 
 	/**

--- a/src/Docx.ts
+++ b/src/Docx.ts
@@ -149,7 +149,7 @@ export class Docx<PropsGeneric extends { [key: string]: unknown } = { [key: stri
 					}
 
 					if (relationships !== null) {
-						component.ensureRelationship(relationships);
+						await component.ensureRelationship(relationships);
 					}
 
 					await Promise.all((component.children as AnyComponent[]).map(walk));

--- a/src/classes/BinaryFile.ts
+++ b/src/classes/BinaryFile.ts
@@ -57,8 +57,12 @@ export class BinaryFile {
 		return new BinaryFile(location, () => Deno.readFile(diskLocation));
 	}
 
-	public static fromData(data: Uint8Array | Promise<Uint8Array>, location: string): BinaryFile {
-		return new BinaryFile(location, () => Promise.resolve(data));
+	public static fromData(
+		data: Uint8Array | Promise<Uint8Array>,
+		location: string,
+		mime?: FileMime,
+	): BinaryFile {
+		return new BinaryFile(location, () => Promise.resolve(data), mime);
 	}
 
 	public toUint8Array(): Promise<Uint8Array> {

--- a/src/classes/BinaryFile.ts
+++ b/src/classes/BinaryFile.ts
@@ -50,7 +50,7 @@ export class BinaryFile {
 		const mime = contentTypes.getType(location);
 		if (mime === undefined) {
 			throw new Error(
-				'Error creating BinaryFile from Archrive. No matching content type found in ContentTypesXML',
+				'Error creating BinaryFile from Archive. No matching content type found in ContentTypesXml',
 			);
 		}
 

--- a/src/classes/BinaryFile.ts
+++ b/src/classes/BinaryFile.ts
@@ -1,6 +1,6 @@
+import { ContentTypesXml } from '../../mod.ts';
 import { FileMime } from '../enums.ts';
 import { type File } from '../files/RelationshipsXml.ts';
-import { getMimeTypeForUint8Array } from '../utilities/mime-types.ts';
 import { Archive } from './Archive.ts';
 
 type BinaryFileReader = () => Promise<Uint8Array>;
@@ -11,11 +11,11 @@ type BinaryFileReader = () => Promise<Uint8Array>;
  */
 export class BinaryFile {
 	public readonly location: string;
-	public mime?: FileMime;
+	public mime: FileMime;
 
 	readonly #reader: BinaryFileReader;
 
-	protected constructor(location: string, reader: BinaryFileReader, mime?: FileMime) {
+	protected constructor(location: string, reader: BinaryFileReader, mime: FileMime) {
 		this.location = location;
 		this.mime = mime;
 		this.#reader = reader;
@@ -32,14 +32,7 @@ export class BinaryFile {
 	}
 
 	public get contentType(): Promise<FileMime> {
-		if (this.mime) {
-			return Promise.resolve(this.mime);
-		}
-
-		return this.toUint8Array().then((data) => {
-			this.mime = getMimeTypeForUint8Array(data);
-			return this.mime;
-		});
+		return Promise.resolve(this.mime);
 	}
 
 	/**
@@ -49,18 +42,29 @@ export class BinaryFile {
 		return false;
 	}
 
-	public static fromArchive(archive: Archive, location: string): BinaryFile {
-		return new BinaryFile(location, () => archive.readBinary(location));
+	public static fromArchive(
+		archive: Archive,
+		contentTypes: ContentTypesXml,
+		location: string,
+	): BinaryFile {
+		const mime = contentTypes.getType(location);
+		if (mime === undefined) {
+			throw new Error(
+				'Error creating BinaryFile from Archrive. No matching content type found in ContentTypesXML',
+			);
+		}
+
+		return new BinaryFile(location, () => archive.readBinary(location), mime);
 	}
 
-	public static fromDisk(diskLocation: string, location: string): BinaryFile {
-		return new BinaryFile(location, () => Deno.readFile(diskLocation));
+	public static fromDisk(diskLocation: string, location: string, mime: FileMime): BinaryFile {
+		return new BinaryFile(location, () => Deno.readFile(diskLocation), mime);
 	}
 
 	public static fromData(
 		data: Uint8Array | Promise<Uint8Array>,
 		location: string,
-		mime?: FileMime,
+		mime: FileMime,
 	): BinaryFile {
 		return new BinaryFile(location, () => Promise.resolve(data), mime);
 	}

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -302,7 +302,7 @@ export class Image extends Component<ImageProps, ImageChild> {
 		if (blipNode === null) {
 			throw new Error('Failed to load image. No blip found inside a blipFill.');
 		}
-		const { main, svg } = extractData(archive, relationships, blipNode);
+		const { main, svg } = extractDataFromBlipNode(archive, relationships, blipNode);
 
 		const dataExtensions: DataExtensions = {};
 		if (svg) {
@@ -330,31 +330,27 @@ export class Image extends Component<ImageProps, ImageChild> {
 
 registerComponent(Image as unknown as ComponentDefinition);
 
-type BlipLocationAndData = {
-	data: Promise<Uint8Array>;
-	location: string;
+type ExtractedBlipNodeData = {
+	main: {
+		data: Promise<Uint8Array>;
+		location: string;
+	};
+	svg?: {
+		data: Promise<string>;
+		location: string;
+	};
 };
 
-type BlipSvgLocationAndData = {
-	data: Promise<string>;
-	location: string;
-};
-
-type BlipAllLocationsAndData = {
-	main: BlipLocationAndData;
-	svg?: BlipSvgLocationAndData;
-};
-
-function extractData(
+function extractDataFromBlipNode(
 	archive: Archive,
 	relationships: RelationshipsXml,
 	blipNode: Node,
-): BlipAllLocationsAndData {
+): ExtractedBlipNodeData {
 	const blipEmbedRel = evaluateXPathToString(`@${QNS.r}embed/string()`, blipNode);
 	const location = relationships.getTarget(blipEmbedRel);
 	const data = archive.readBinary(location);
 
-	const allLocationsAndData: BlipAllLocationsAndData = {
+	const allLocationsAndData: ExtractedBlipNodeData = {
 		main: {
 			data,
 			location,

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -380,7 +380,7 @@ function extractData(
 			const extensionRel = element.children[0].getAttributeNS(NamespaceUri.r, 'embed');
 			if (extensionRel === null) {
 				throw new Error(
-					'Failed to load image SVG extension. SVG extension URI found in extLst but it does not follow the known format.',
+					'Failed to load image SVG extension. SVG extension URI found in extLst but its node does not follow the known format.',
 				);
 			}
 			const location = relationships.getTarget(extensionRel);

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -227,7 +227,7 @@ export class Image extends Component<ImageProps, ImageChild> {
 											element ${QNS.a}blip {
 												attribute ${QNS.r}embed { $relationshipId },
 												attribute cstate { "print" },
-												${extensionList ? '$extensionList' : '()'}
+												$extensionList
 											},
 											element ${QNS.a}stretch {
 												element ${QNS.a}fillRect {}

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -56,10 +56,12 @@ export class Image extends Component<ImageProps, ImageChild> {
 	 * An event hook with which this component can ensure that the correct relationship type is
 	 * recorded to the relationship XML.
 	 */
-	public ensureRelationship(relationships: RelationshipsXml) {
+	public async ensureRelationship(relationships: RelationshipsXml) {
+		const mime = await this.getMimeType();
+
 		this.#relationshipId = relationships.add(
 			RelationshipType.image,
-			BinaryFile.fromData(this.props.data, this.#location),
+			BinaryFile.fromData(this.props.data, this.#location, mime),
 		);
 	}
 

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -319,17 +319,10 @@ export class Image extends Component<ImageProps, ImageChild> {
 		image.#meta.location = main.location;
 		if (svg) {
 			const { svg: svgMeta } = image.#meta.extensions;
-			if (!svgMeta) {
-				// At the time of writing this error should never happen.
-				// If you encountered it, it probably means that the Image constructor
-				// changed and is no longer defining #embed.svg when dataExtensions.svg
-				// is passed or this method changed and no longer passes
-				// dataExtensions.svg to the Image costuctor.
-				throw new Error(
-					'Failed setting image #embed.svg.location during Image deserialization. No SVG properties are available',
-				);
-			}
-			svgMeta.location = svg.location;
+			// We are certain that if we pass `dataExtensions` with `svg` in it
+			// `Image` construtor makes it so image.#meta.extensions has `svg` too.
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			svgMeta!.location = svg.location;
 		}
 		return image;
 	}

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -37,10 +37,11 @@ export enum FileMime {
 	comments = 'application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml',
 	numbering = 'application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml',
 
-	// Binary content types
+	// Images
 	jpeg = 'image/jpeg',
 	png = 'image/png',
 	gif = 'image/gif',
+	svg = 'image/svg+xml',
 }
 
 export enum RelationshipType {

--- a/src/files/CommentsXml.ts
+++ b/src/files/CommentsXml.ts
@@ -1,8 +1,9 @@
 import * as path from 'https://deno.land/std@0.187.0/path/mod.ts';
 
+import { ContentTypesXml } from '../../mod.ts';
 import { Archive } from '../classes/Archive.ts';
 import { NumberMap } from '../classes/NumberMap.ts';
-import { XmlFile } from '../classes/XmlFile.ts';
+import { XmlFileWithContentTypes } from '../classes/XmlFile.ts';
 import { Paragraph } from '../components/Paragraph.ts';
 import { FileMime } from '../enums.ts';
 import { create } from '../utilities/dom.ts';
@@ -18,7 +19,7 @@ type Comment = {
 	contents: Paragraph[] | Promise<Paragraph[]>;
 };
 
-export class CommentsXml extends XmlFile {
+export class CommentsXml extends XmlFileWithContentTypes {
 	public static contentType = FileMime.comments;
 
 	#comments = new NumberMap<Comment>();
@@ -83,12 +84,16 @@ export class CommentsXml extends XmlFile {
 	/**
 	 * Instantiate this class by looking at the DOCX XML for it.
 	 */
-	public static async fromArchive(archive: Archive, location: string): Promise<CommentsXml> {
+	public static async fromArchive(
+		archive: Archive,
+		contentTypes: ContentTypesXml,
+		location: string,
+	): Promise<CommentsXml> {
 		const dom = await archive.readXml(location);
 
 		const relsLocation = `${path.dirname(location)}/_rels/${path.basename(location)}.rels`;
 		const relationships = archive.hasFile(relsLocation)
-			? await RelationshipsXml.fromArchive(archive, relsLocation)
+			? await RelationshipsXml.fromArchive(archive, contentTypes, relsLocation)
 			: null;
 
 		const inst = new this(location);

--- a/src/files/ContentTypesXml.ts
+++ b/src/files/ContentTypesXml.ts
@@ -12,7 +12,7 @@ type ContentTypeOverride = {
 
 type ContentTypeDefault = {
 	extension: string;
-	contentType: string | FileMime;
+	contentType: FileMime;
 };
 
 export class ContentTypesXml extends XmlFile {
@@ -35,7 +35,7 @@ export class ContentTypesXml extends XmlFile {
 	/**
 	 * Add a default content type association for a file extension.
 	 */
-	public addDefault(extension: string, contentType: string | FileMime): void {
+	public addDefault(extension: string, contentType: FileMime): void {
 		const exists = this.#defaults.findIndex((item) => item.extension === extension);
 		if (exists >= 0) {
 			this.#defaults.splice(exists, 1);
@@ -61,6 +61,18 @@ export class ContentTypesXml extends XmlFile {
 			this.#overrides.splice(exists, 1);
 		}
 		this.#overrides.push({ partName, contentType });
+	}
+
+	public getType(location: string): FileMime | undefined {
+		const indexInOverides = this.#overrides.findIndex((item) => item.partName === location);
+		if (indexInOverides >= 0) {
+			return this.#overrides[indexInOverides].contentType;
+		}
+
+		const indexInDefaults = this.#defaults.findIndex((item) => location.endsWith(item.extension));
+		if (indexInDefaults >= 0) {
+			return this.#defaults[indexInDefaults].contentType;
+		}
 	}
 
 	protected toNode(): Document {

--- a/src/files/DocumentXml.ts
+++ b/src/files/DocumentXml.ts
@@ -1,8 +1,9 @@
 import * as path from 'https://deno.land/std@0.187.0/path/mod.ts';
 
+import { ContentTypesXml } from '../../mod.ts';
 import { Archive } from '../classes/Archive.ts';
 import { ComponentContext } from '../classes/Component.ts';
-import { XmlFile } from '../classes/XmlFile.ts';
+import { XmlFileWithContentTypes } from '../classes/XmlFile.ts';
 import { Paragraph } from '../components/Paragraph.ts';
 import { type SectionChild, Section, sectionChildComponentNames } from '../components/Section.ts';
 import { Table } from '../components/Table.ts';
@@ -22,7 +23,7 @@ export type DocumentChild = SectionChild | Section;
 
 export type DocumentRoot = DocumentChild | DocumentChild[] | Promise<DocumentChild[]>;
 
-export class DocumentXml extends XmlFile {
+export class DocumentXml extends XmlFileWithContentTypes {
 	public static contentType = FileMime.mainDocument;
 
 	public readonly relationships: RelationshipsXml;
@@ -197,9 +198,14 @@ export class DocumentXml extends XmlFile {
 	/**
 	 * Instantiate this class by looking at the DOCX XML for it.
 	 */
-	public static async fromArchive(archive: Archive, location: string): Promise<DocumentXml> {
+	public static async fromArchive(
+		archive: Archive,
+		contentTypes: ContentTypesXml,
+		location: string,
+	): Promise<DocumentXml> {
 		const relationships = await RelationshipsXml.fromArchive(
 			archive,
+			contentTypes,
 			`${path.dirname(location)}/_rels/${path.basename(location)}.rels`,
 		);
 		const doc = new DocumentXml(location, relationships);

--- a/src/files/HeaderFooterXml.ts
+++ b/src/files/HeaderFooterXml.ts
@@ -1,8 +1,9 @@
 import * as path from 'https://deno.land/std@0.187.0/path/mod.ts';
 
+import { ContentTypesXml } from '../../mod.ts';
 import { Archive } from '../classes/Archive.ts';
 import { type AnyComponent } from '../classes/Component.ts';
-import { XmlFile } from '../classes/XmlFile.ts';
+import { XmlFileWithContentTypes } from '../classes/XmlFile.ts';
 import { Paragraph } from '../components/Paragraph.ts';
 import { Table } from '../components/Table.ts';
 import { WatermarkText } from '../components/WatermarkText.ts';
@@ -20,7 +21,7 @@ export type HeaderFooterRoot<Child = HeaderFooterChild> = Child | Child[] | Prom
 /**
  * Somewhat generic implementation of either the Header or Footer helper classes.
  */
-class HeaderFooterAbstractionXml<Child extends AnyComponent> extends XmlFile {
+class HeaderFooterAbstractionXml<Child extends AnyComponent> extends XmlFileWithContentTypes {
 	#nodeName: string;
 
 	#root: HeaderFooterRoot<Child> | null = null;
@@ -103,11 +104,15 @@ export class HeaderXml extends HeaderFooterAbstractionXml<HeaderFooterChild | Wa
 	/**
 	 * Instantiate this class by looking at the DOCX XML for it.
 	 */
-	public static async fromArchive(archive: Archive, location: string) {
+	public static async fromArchive(
+		archive: Archive,
+		contentTypes: ContentTypesXml,
+		location: string,
+	) {
 		const dom = await archive.readXml(location);
 		const relsLocation = `${path.dirname(location)}/_rels/${path.basename(location)}.rels`;
 		const relationships = archive.hasFile(relsLocation)
-			? await RelationshipsXml.fromArchive(archive, relsLocation)
+			? await RelationshipsXml.fromArchive(archive, contentTypes, relsLocation)
 			: null;
 		const inst = new this(location, relationships);
 		inst.set(
@@ -147,11 +152,15 @@ export class FooterXml extends HeaderFooterAbstractionXml<HeaderFooterChild> {
 	/**
 	 * Instantiate this class by looking at the DOCX XML for it.
 	 */
-	public static async fromArchive(archive: Archive, location: string) {
+	public static async fromArchive(
+		archive: Archive,
+		contentTypes: ContentTypesXml,
+		location: string,
+	) {
 		const dom = await archive.readXml(location);
 		const relsLocation = `${path.dirname(location)}/_rels/${path.basename(location)}.rels`;
 		const relationships = archive.hasFile(relsLocation)
-			? await RelationshipsXml.fromArchive(archive, relsLocation)
+			? await RelationshipsXml.fromArchive(archive, contentTypes, relsLocation)
 			: null;
 		const inst = new this(location, relationships);
 		inst.set(

--- a/src/files/RelationshipsXml.test.ts
+++ b/src/files/RelationshipsXml.test.ts
@@ -2,15 +2,16 @@ import { beforeAll, describe, expect, it, run } from 'https://deno.land/x/tincan
 
 import { serialize } from '../utilities/dom.ts';
 import { archive } from '../utilities/tests.ts';
+import { ContentTypesXml } from './ContentTypesXml.ts';
 import { RelationshipsXml } from './RelationshipsXml.ts';
 
 describe('Relationships', () => {
 	let relationships: RelationshipsXml;
+	let contentTypes: ContentTypesXml;
 	beforeAll(async () => {
-		relationships = await RelationshipsXml.fromArchive(
-			await archive('test/simple.docx'),
-			'_rels/.rels',
-		);
+		const arch = await archive('test/simple.docx');
+		contentTypes = await ContentTypesXml.fromArchive(arch, '[Content_Types].xml');
+		relationships = await RelationshipsXml.fromArchive(arch, contentTypes, '_rels/.rels');
 	});
 
 	it('serializes correctly', async () => {

--- a/src/files/RelationshipsXml.ts
+++ b/src/files/RelationshipsXml.ts
@@ -204,7 +204,7 @@ export class RelationshipsXml extends XmlFileWithContentTypes {
 					.map(async (meta) => ({
 						...meta,
 						instance: meta.isBinary
-							? await BinaryFile.fromArchive(archive, meta.target)
+							? await BinaryFile.fromArchive(archive, contentTypes, meta.target)
 							: await castRelationshipToClass(archive, contentTypes, {
 									type: meta.type,
 									target: meta.target,

--- a/src/files/RelationshipsXml.ts
+++ b/src/files/RelationshipsXml.ts
@@ -1,8 +1,9 @@
 import { posix as path } from 'https://deno.land/std@0.187.0/path/mod.ts';
 
+import { ContentTypesXml } from '../../mod.ts';
 import { Archive } from '../classes/Archive.ts';
 import { BinaryFile } from '../classes/BinaryFile.ts';
-import { XmlFile } from '../classes/XmlFile.ts';
+import { XmlFile, XmlFileWithContentTypes } from '../classes/XmlFile.ts';
 import { FileMime, RelationshipType } from '../enums.ts';
 import { create } from '../utilities/dom.ts';
 import { createRandomId } from '../utilities/identifiers.ts';
@@ -20,7 +21,7 @@ export type RelationshipMeta = {
 
 export type File = XmlFile | BinaryFile;
 
-export class RelationshipsXml extends XmlFile {
+export class RelationshipsXml extends XmlFileWithContentTypes {
 	public static contentType = FileMime.relationships;
 
 	/**
@@ -175,7 +176,11 @@ export class RelationshipsXml extends XmlFile {
 	/**
 	 * Instantiate this class by looking at the DOCX XML for it.
 	 */
-	public static async fromArchive(archive: Archive, location: string): Promise<RelationshipsXml> {
+	public static async fromArchive(
+		archive: Archive,
+		contentTypes: ContentTypesXml,
+		location: string,
+	): Promise<RelationshipsXml> {
 		const meta = evaluateXPathToArray(
 			`
 				array{/*/Relationship/map{
@@ -200,7 +205,7 @@ export class RelationshipsXml extends XmlFile {
 						...meta,
 						instance: meta.isBinary
 							? await BinaryFile.fromArchive(archive, meta.target)
-							: await castRelationshipToClass(archive, {
+							: await castRelationshipToClass(archive, contentTypes, {
 									type: meta.type,
 									target: meta.target,
 							  }),

--- a/src/files/SettingsXml.ts
+++ b/src/files/SettingsXml.ts
@@ -1,7 +1,8 @@
 import * as path from 'https://deno.land/std@0.187.0/path/mod.ts';
 
+import { ContentTypesXml } from '../../mod.ts';
 import { Archive } from '../classes/Archive.ts';
-import { XmlFile } from '../classes/XmlFile.ts';
+import { XmlFileWithContentTypes } from '../classes/XmlFile.ts';
 import { FileMime, RelationshipType } from '../enums.ts';
 import { create } from '../utilities/dom.ts';
 import { ALL_NAMESPACE_DECLARATIONS, QNS } from '../utilities/namespaces.ts';
@@ -63,7 +64,7 @@ const settingsMeta: Array<SettingMeta> = [
 	},
 ];
 
-export class SettingsXml extends XmlFile {
+export class SettingsXml extends XmlFileWithContentTypes {
 	public static contentType = FileMime.settings;
 
 	public readonly relationships: RelationshipsXml;
@@ -159,12 +160,20 @@ export class SettingsXml extends XmlFile {
 	/**
 	 * Instantiate this class by looking at the DOCX XML for it.
 	 */
-	public static async fromArchive(archive: Archive, location: string): Promise<SettingsXml> {
+	public static async fromArchive(
+		archive: Archive,
+		contentTypes: ContentTypesXml,
+		location: string,
+	): Promise<SettingsXml> {
 		let relationships;
 
 		const relationshipsLocation = `${path.dirname(location)}/_rels/${path.basename(location)}.rels`;
 		try {
-			relationships = await RelationshipsXml.fromArchive(archive, relationshipsLocation);
+			relationships = await RelationshipsXml.fromArchive(
+				archive,
+				contentTypes,
+				relationshipsLocation,
+			);
 		} catch (_error: unknown) {
 			// console.error(
 			// 	'Warning, relationships could not be resolved\n' +

--- a/src/files/index.ts
+++ b/src/files/index.ts
@@ -1,3 +1,4 @@
+import { ContentTypesXml } from '../../mod.ts';
 import { Archive } from '../classes/Archive.ts';
 import { UnhandledXmlFile } from '../classes/XmlFile.ts';
 import { RelationshipType } from '../enums.ts';
@@ -23,6 +24,7 @@ import { WebSettingsXml } from './wip/WebSettingsXml.ts';
  */
 export function castRelationshipToClass(
 	archive: Archive,
+	contentTypes: ContentTypesXml,
 	meta: Pick<RelationshipMeta, 'type' | 'target'>,
 ) {
 	switch (meta.type) {
@@ -37,19 +39,19 @@ export function castRelationshipToClass(
 		case RelationshipType.fontTable:
 			return FontTableXml.fromArchive(archive, meta.target);
 		case RelationshipType.footer:
-			return FooterXml.fromArchive(archive, meta.target);
+			return FooterXml.fromArchive(archive, contentTypes, meta.target);
 		case RelationshipType.footnotes:
 			return FootnotesXml.fromArchive(archive, meta.target);
 		case RelationshipType.header:
-			return HeaderXml.fromArchive(archive, meta.target);
+			return HeaderXml.fromArchive(archive, contentTypes, meta.target);
 		case RelationshipType.officeDocument:
-			return DocumentXml.fromArchive(archive, meta.target);
+			return DocumentXml.fromArchive(archive, contentTypes, meta.target);
 		case RelationshipType.settings:
-			return SettingsXml.fromArchive(archive, meta.target);
+			return SettingsXml.fromArchive(archive, contentTypes, meta.target);
 		case RelationshipType.styles:
 			return StylesXml.fromArchive(archive, meta.target);
 		case RelationshipType.comments:
-			return CommentsXml.fromArchive(archive, meta.target);
+			return CommentsXml.fromArchive(archive, contentTypes, meta.target);
 		case RelationshipType.theme:
 			return ThemeXml.fromArchive(archive, meta.target);
 		case RelationshipType.webSettings:

--- a/src/utilities/drawingml-extensions.ts
+++ b/src/utilities/drawingml-extensions.ts
@@ -1,0 +1,14 @@
+/**
+ * Values that can be used as `uri` attributes of DrawingML ExtensionList children.
+ * @see {@link https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.extensionlist?view=openxml-2.8.1}
+ */
+export const extensionListUris = {
+	/** @see {@link https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.office2010.drawing.uselocaldpi?view=openxml-2.8.1} */
+	useLocalDpi: '{28A0092B-C50C-407E-A947-70E740481C1C}',
+
+	/**
+	 * Unfortunately this URI is not documented. There is also no official name
+	 * for the extension it represents so we just call it 'svg'.
+	 */
+	svg: '{96DAC541-7B7A-43D3-8B79-37D633B846F1}',
+};

--- a/src/utilities/namespaces.ts
+++ b/src/utilities/namespaces.ts
@@ -46,6 +46,8 @@ export const NamespaceUri = {
 
 	// Drawings/images
 	a: 'http://schemas.openxmlformats.org/drawingml/2006/main',
+	asvg: 'http://schemas.microsoft.com/office/drawing/2016/SVG/main',
+	a14: 'http://schemas.microsoft.com/office/drawing/2010/main',
 	pic: 'http://schemas.openxmlformats.org/drawingml/2006/picture',
 };
 

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -8,7 +8,8 @@ import { describe, expect, it } from 'https://deno.land/x/tincan@1.0.1/mod.ts';
 import { Archive } from '../classes/Archive.ts';
 import { XmlFile } from '../classes/XmlFile.ts';
 import { Docx } from '../Docx.ts';
-import { RelationshipType } from '../enums.ts';
+import { FileLocation, RelationshipType } from '../enums.ts';
+import { ContentTypesXml } from '../files/ContentTypesXml.ts';
 import { castRelationshipToClass } from '../files/index.ts';
 import { create } from './dom.ts';
 import { evaluateXPathToBoolean } from './xquery.ts';
@@ -67,7 +68,8 @@ export async function archivedFile(
 	fileLocation: string,
 ) {
 	const zip = await archive(archiveLocation);
-	return castRelationshipToClass(zip, { type, target: fileLocation });
+	const contentTypes = await ContentTypesXml.fromArchive(zip, FileLocation.contentTypes);
+	return castRelationshipToClass(zip, contentTypes, { type, target: fileLocation });
 }
 
 /**

--- a/test/git.svg
+++ b/test/git.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 120 70" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20,20h20m5,0h20m5,0h20" stroke="#c00000" stroke-width="10"/>
+  <path d="M20,40h20m5,0h20m5,0h20M30,30v20m25,0v-20m25,0v20" stroke="#008000" stroke-width="6"/>
+</svg>


### PR DESCRIPTION
# Motivation

Microsoft Word starting with the 2016 version supports adding SVG data to DrawingML blips via [extensions](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.presentation.extensionlist?view=openxml-2.8.1). Docxml does not support any blip extensions so adding SVG data is impossible and it is lost during re-serialization.

# Solution

Even though the main goal of this PR remains implementing SVG support, the majority of the changes address the handling of MIME types because previously an assumption was made that the type can be always determined by looking at the first few bytes of the file data and `[Content_Types].xml` file was mostly ignored. This change had to be made because that assumption did not work consistently for SVG files which can start with white space, XML comments or have the root element prefixed with a namespace qualifier.

Additionally, this PR makes it so `BinaryFiles`s always have the `mime` property and removes the use of `getMimeTypeForUint8Array()` from them completely which is a non-mandatory change but can help users avoid errors by making  `BinaryFiles` non-throwing.

Finally, this PR also adds the ability to optionally specify SVG data for `Image` elements using the optional `dataExtensions` property (which attempts to mimic the OpenXML design and future proof the component for other extensions), and adds the ability to deserialize that data from `Archive`.

# Breaking changes

* `Image` no longer has the `getMimeType` method. Use `meta.mime` instead.