### PR TITLE
Fix `Image` searilization and `mime` handling

### DIFF
--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -114,7 +114,7 @@ export class Image extends Component<ImageProps, ImageChild> {
 
 		this.#meta = {
 			location: `word/media/${createRandomId('img')}`,
-			mime: null,
+			mime: props.mime ? Promise.resolve(props.mime) : null,
 			relationshipId: null,
 			extensions: {},
 		};

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -163,7 +163,7 @@ export class Image extends Component<ImageProps, ImageChild> {
 			throw new Error('Cannot serialize an image outside the context of an Document');
 		}
 
-		let extensionList: Node | undefined;
+		let extensionList: Node | null = null;
 		const { svg } = this.meta.extensions;
 		if (svg) {
 			extensionList = create(

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -213,44 +213,43 @@ export class Image extends Component<ImageProps, ImageChild> {
 						(: nb: _Must_ be prefixed with "a" or MS Word will refuse to open :)
 						element ${QNS.a}graphic {
 							element ${QNS.a}graphicData {
-									attribute uri { "${NamespaceUri.pic}"},
-									element ${QNS.pic}pic {
-										element ${QNS.pic}nvPicPr {
-											element ${QNS.pic}cNvPr {
-												attribute id { $identifier },
-												attribute name { $name },
-												attribute descr { $desc }
-											},
-											element ${QNS.pic}cNvPicPr {}
+								attribute uri { "${NamespaceUri.pic}"},
+								element ${QNS.pic}pic {
+									element ${QNS.pic}nvPicPr {
+										element ${QNS.pic}cNvPr {
+											attribute id { $identifier },
+											attribute name { $name },
+											attribute descr { $desc }
 										},
-										element ${QNS.pic}blipFill {
-											element ${QNS.a}blip {
-												attribute ${QNS.r}embed { $relationshipId },
-												attribute cstate { "print" },
-												$extensionList
+										element ${QNS.pic}cNvPicPr {}
+									},
+									element ${QNS.pic}blipFill {
+										element ${QNS.a}blip {
+											attribute ${QNS.r}embed { $relationshipId },
+											attribute cstate { "print" },
+											$extensionList
+										},
+										element ${QNS.a}stretch {
+											element ${QNS.a}fillRect {}
+										}
+									},
+									element ${QNS.pic}spPr {
+										element ${QNS.a}xfrm {
+											element ${QNS.a}off {
+												attribute x { "0" },
+												attribute y { "0" }
 											},
-											element ${QNS.a}stretch {
-												element ${QNS.a}fillRect {}
+											element ${QNS.a}ext {
+												attribute cx { $width },
+												attribute cy { $height }
 											}
 										},
-										element ${QNS.pic}spPr {
-											element ${QNS.a}xfrm {
-												element ${QNS.a}off {
-													attribute x { "0" },
-													attribute y { "0" }
-												},
-												element ${QNS.a}ext {
-													attribute cx { $width },
-													attribute cy { $height }
-												}
-											},
-											element ${QNS.a}prstGeom {
-												attribute prst { "rect" },
-												element ${QNS.a}avLst {}
-											}
+										element ${QNS.a}prstGeom {
+											attribute prst { "rect" },
+											element ${QNS.a}avLst {}
 										}
 									}
-
+								}
 							}
 						}
 					}


### PR DESCRIPTION
I made two mistakes in my previous PR (#31) and forgot to include a minor formatting improvement.

This PR:
* Fixes the `Image` constructor ignoring the `mime` prop.
* Fixes `Image.toNode()` crashing when not using `dataExtensions.svg`.
* Removes extra indent and empty line the `Image` XQuery code.