### PR TITLE
Add `defaultTabStop` setting

### DIFF
--- a/src/files/SettingsXml.test.ts
+++ b/src/files/SettingsXml.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, run } from 'https://deno.land/x/tincan@1.0.1/mod.ts';
 
 import { RelationshipType } from '../enums.ts';
+import { pt } from '../utilities/length.ts';
 import { SettingsXml } from './SettingsXml.ts';
 
 describe('SettingsXml', () => {
@@ -26,6 +27,12 @@ describe('SettingsXml', () => {
 		);
 		expect(meta).toBeTruthy();
 		expect(settings.relationships.getTarget(meta?.id as string)).toBe('foobar');
+	});
+	it('defaultTabStop', () => {
+		const settings = new SettingsXml('test');
+		expect(settings.get('defaultTabStop')).toBe(null);
+		settings.set('defaultTabStop', pt(50));
+		expect(settings.get('defaultTabStop')).toEqual(pt(50));
 	});
 });
 


### PR DESCRIPTION
This PR adds the ability to work with the [defaultTabStop](http://www.datypic.com/sc/ooxml/e-w_defaultTabStop-1.html) setting.

The setting can be set, retrieved, serialized and de-serialized.